### PR TITLE
makefile: binary depends on source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: build listing
 build: $(OUT_FILE).hex
 listing: $(OUT_FILE).lst
 
-$(OUT_FILE):
+$(OUT_FILE): blink.rs Cargo.toml
 	cargo build --release --target=$(TARGET) --verbose
 
 $(OUT_DIR)/%.hex: $(OUT_DIR)/%


### PR DESCRIPTION
Without this if you edit the source and re-run e.g. `make load`, it doesn't rebuild from source.
